### PR TITLE
fix(Windows): 修复非隐藏 webview 窗口任务栏图标不显示的问题

### DIFF
--- a/api/window/window.cpp
+++ b/api/window/window.cpp
@@ -159,9 +159,9 @@ namespace window {
             y = pos.second;
         }
         ShowWindow(windowHandle, SW_HIDE);
-        SetWindowLong(windowHandle, GWL_EXSTYLE, nativeWindow->m_originalStyleEx);
+        SetWindowLong(windowHandle, GWL_EXSTYLE, nativeWindow->m_originalStyleEx | WS_EX_APPWINDOW);
         SetWindowPos(windowHandle, nullptr,
-            x, y, 0, 0, SWP_NOZORDER | SWP_NOSIZE);
+            x, y, 0, 0, SWP_NOZORDER | SWP_NOSIZE | SWP_FRAMECHANGED);
         ShowWindow(windowHandle, SW_SHOW);
     }
 #endif
@@ -307,7 +307,8 @@ namespace window {
             ShowWindow(windowHandle, SW_SHOW);
         }
 
-        SetWindowPos(windowHandle, HWND_TOP, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW);
+        SetWindowLong(windowHandle, GWL_EXSTYLE, nativeWindow->m_originalStyleEx | WS_EX_APPWINDOW);
+        SetWindowPos(windowHandle, HWND_TOP, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW | SWP_FRAMECHANGED);
 
         if (!SetForegroundWindow(windowHandle))
         {
@@ -567,7 +568,7 @@ namespace window {
         void __createWindow() {
             savedState = windowProps.useSavedState && __loadSavedWindowProps();
 
-            nativeWindow = new webview::webview(windowProps.enableInspector, nullptr, windowProps.transparent);
+            nativeWindow = new webview::webview(windowProps.enableInspector, nullptr, windowProps.transparent, windowProps.hidden);
             nativeWindow->set_title(windowProps.title);
             if (windowProps.extendUserAgentWith != "")
             {

--- a/lib/webview/webview.h
+++ b/lib/webview/webview.h
@@ -94,7 +94,7 @@ namespace webview {
 
     class gtk_webkit_engine {
     public:
-        gtk_webkit_engine(bool debug, void* window, bool transparent)
+        gtk_webkit_engine(bool debug, void* window, bool transparent, bool hidden = false)
             : m_window(static_cast<GtkWidget*>(window)) {
 
             XInitThreads();
@@ -316,7 +316,7 @@ namespace webview {
 
     class cocoa_wkwebview_engine {
     public:
-        cocoa_wkwebview_engine(bool debug, void* window, bool transparent) {
+        cocoa_wkwebview_engine(bool debug, void* window, bool transparent, bool hidden = false) {
             // Application
             id app = ((id(*)(id, SEL))objc_msgSend)("NSApplication"_cls,
                 "sharedApplication"_sel);
@@ -854,7 +854,8 @@ namespace webview {
 
     class win32_edge_engine {
     public:
-        win32_edge_engine(bool debug, void* window, bool transparent) {
+        win32_edge_engine(bool debug, void* window, bool transparent, bool hidden = false)
+            : m_hidden(hidden) {
             if (window == nullptr)
             {
                 HINSTANCE hInstance = GetModuleHandle(nullptr);
@@ -1006,8 +1007,14 @@ namespace webview {
             }
 
             // stop the taskbar icon from showing by removing WS_EX_APPWINDOW.
-            SetWindowLong(m_window, GWL_EXSTYLE, GetWindowLong(m_window, GWL_EXSTYLE) & ~WS_EX_APPWINDOW);
-            ShowWindow(m_window, SW_SHOW);
+            if (hidden) {
+                SetWindowLong(m_window, GWL_EXSTYLE, GetWindowLong(m_window, GWL_EXSTYLE) & ~WS_EX_APPWINDOW);
+                ShowWindow(m_window, SW_HIDE);
+            }
+            else
+            {
+                ShowWindow(m_window, SW_SHOW);
+            }
             UpdateWindow(m_window);
             SetForegroundWindow(m_window);
 
@@ -1132,6 +1139,7 @@ namespace webview {
         }
 
         DWORD m_originalStyleEx;
+        bool m_hidden;
 
     private:
 
@@ -1177,8 +1185,8 @@ namespace webview {
 
     class webview : public browser_engine {
     public:
-        webview(bool debug = false, void* wnd = nullptr, bool transparent = false)
-            : browser_engine(debug, wnd, transparent) {}
+        webview(bool debug = false, void* wnd = nullptr, bool transparent = false, bool hidden = false)
+            : browser_engine(debug, wnd, transparent, hidden) {}
 
         void navigate(const std::string url) {
             browser_engine::navigate(url);


### PR DESCRIPTION
## 问题描述
在 Windows 上，创建 webview 窗口时无条件地移除了 `WS_EX_APPWINDOW` 扩展窗口样式。该样式是顶层窗口在任务栏显示按钮/图标的必要条件，因此普通（非隐藏）窗口的任务栏图标会随机缺失。

## 改动内容
- `lib/webview/webview.h`
  - 为引擎和 `webview` 构造函数新增 `hidden` 参数。
  - `win32_edge_engine` 仅在窗口被配置为隐藏时才移除 `WS_EX_APPWINDOW`，否则保持该样式。
  - Linux/macOS 引擎也接受新参数但使用默认值，保持跨平台兼容。
- `api/window/window.cpp`
  - 创建窗口时将 `windowProps.hidden` 传入 webview 构造函数。
  - 在 `window::show()` 和 `__undoFakeHidden()` 中恢复 `WS_EX_APPWINDOW`，确保窗口变为可见时任务栏图标能正确出现。

## 测试计划
- [ ] 在 Windows 上编译通过。
- [ ] 运行 `hidden: false` 的 Neutralino 应用，确认任务栏图标稳定显示。
- [ ] 运行 `hidden: true` 的 Neutralino 应用，确认窗口初始隐藏，调用 `Neutralino.window.show()` 后窗口显示且任务栏图标出现。

🤖 Generated with [Claude Code](https://claude.com/claude-code)